### PR TITLE
Added config option for orderBy field

### DIFF
--- a/config/laravel-impersonate-ui.php
+++ b/config/laravel-impersonate-ui.php
@@ -27,6 +27,14 @@ return [
 	*/
 	'users_allowed_to_impersonate' => ['admin@example.com'],
 
+    /**
+    * Users orderBy field
+    *
+    * For those who do not have the "name" field, but another one, you can specify here the field to use
+    *
+    */
+    'users_order_field' => 'name',
+
 	/**
 	* Position of icon.
 	* 

--- a/resources/views/impersonate-ui.blade.php
+++ b/resources/views/impersonate-ui.blade.php
@@ -1,3 +1,6 @@
+@php
+    $order_field = config('laravel-impersonate-ui.users_order_field');
+@endphp
 @canImpersonate
 <div id="impersonate-ui" class="position-{{ config('laravel-impersonate-ui.icon_position') }}">
 	<a id="impersonate-ui-icon" onclick="toggleFull()">
@@ -5,9 +8,9 @@
 	</a>
 	<div id="impersonate-ui-fullcontainer" class="hiddenX">
 		<h3 class="h5">Laravel Impersonate UI</h3>
-		Logged on as: <span id="current-user"><strong>{{ Auth::user()->name }}</strong></span><br>
+		Logged on as: <span id="current-user"><strong>{{ Auth::user()->$order_field }}</strong></span><br>
 		@impersonating
-			Real user: <span id="real-user"><strong>{{ $impersonator->name }}</strong></span>
+			Real user: <span id="real-user"><strong>{{ $impersonator->$order_field }}</strong></span>
 		@endImpersonating
 		<form action="{{ route('impersonate-ui.take') }}" method="POST" class="form">
 			@csrf
@@ -17,9 +20,9 @@
 				<select name="impersonate_id" id="impersonate_id" class="custom-select" {!! !config('laravel-impersonate-ui.show_button') ? ' onchange="javascript:this.form.submit()"' : '' !!}>
 					@foreach($users as $user)
 						@canBeImpersonated($user)
-							<option value="{{ $user->id }}">{{ $user->name }}</option>
+							<option value="{{ $user->id }}">{{ $user->$order_field }}</option>
 						@else
-							<option value="{{ $user->id }}" selected disabled>{{ $user->name }}</option>
+							<option value="{{ $user->id }}" selected disabled>{{ $user->$order_field }}</option>
 						@endCanBeImpersonated
 					@endforeach
 				</select>

--- a/src/ImpersonateUi.php
+++ b/src/ImpersonateUi.php
@@ -107,14 +107,14 @@ class ImpersonateUi{
 	static public function getUsers(){
 
 		if(is_array(config('laravel-impersonate-ui.users_only'))){
-			return config('laravel-impersonate-ui.user_model')::whereIn('id', config('laravel-impersonate-ui.users_only'))->orderBy('name')->get();
+			return config('laravel-impersonate-ui.user_model')::whereIn('id', config('laravel-impersonate-ui.users_only'))->orderBy(config('laravel-impersonate-ui.users_order_field'))->get();
 		}
 
 		if(is_array(config('laravel-impersonate-ui.users_exclude'))){
-			return config('laravel-impersonate-ui.user_model')::whereNotIn('id', config('laravel-impersonate-ui.users_exclude'))->orderBy('name')->get();
+			return config('laravel-impersonate-ui.user_model')::whereNotIn('id', config('laravel-impersonate-ui.users_exclude'))->orderBy(config('laravel-impersonate-ui.users_order_field'))->get();
 		}
 
-		return config('laravel-impersonate-ui.user_model')::orderBy('name')->get();
+		return config('laravel-impersonate-ui.user_model')::orderBy(config('laravel-impersonate-ui.users_order_field'))->get();
 
 	}
 


### PR DESCRIPTION
For those who do not have the `name` field, but another one, the option to specify the field to use has been added.

This prevents the exception "Column not found: 1054 Unknown column 'name' in 'ORDER BY'"